### PR TITLE
Fix issue #1: change "Blog Posts" at homepage to "All Blog Posts"

### DIFF
--- a/blog/templates/blog/post_list.html
+++ b/blog/templates/blog/post_list.html
@@ -1,11 +1,12 @@
 {% extends 'blog/base.html' %}
 
-{% block title %}Blog Posts{% endblock %}
+{% block title %}All Blog Posts{% endblock %}
 
 {% block content %}
     <div class="row mb-4 align-items-center">
         <div class="col">
-            <h1 class="display-4 fw-bold text-primary">Blog Posts</h1>
+            <h1 class="display-4 fw-bold text-primary">All Blog Posts</h1>
+
         </div>
         <div class="col text-end">
             <a href="{% url 'post-create' %}" class="btn btn-primary btn-lg shadow-sm">

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -1,3 +1,12 @@
 from django.test import TestCase
 
 # Create your tests here.
+
+from django.test import TestCase
+from django.urls import reverse
+
+class BlogPostListViewTests(TestCase):
+    def test_blog_post_list_title(self):
+        response = self.client.get(reverse('post-list'))
+        self.assertContains(response, 'All Blog Posts')
+


### PR DESCRIPTION
This pull request fixes #1.

The issue has been successfully resolved. The AI agent confirmed that the change from "Blog Posts" to "All Blog Posts" on the homepage is working correctly and the test has passed successfully. The change has been implemented and verified through testing, ensuring that the homepage now displays "All Blog Posts" instead of "Blog Posts".

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌