### PR TITLE
Fix issue #9: add "next" and "previous" buttons to post detail page, then user can move to next post or to previous post

### DIFF
--- a/blog/templates/blog/post_detail.html
+++ b/blog/templates/blog/post_detail.html
@@ -26,9 +26,22 @@
                     Delete Post
                 </a>
             </div>
-            <a href="{% url 'post-list' %}" class="btn btn-outline-secondary float-end">
+            <div class="btn-group float-end">
+                {% if previous_post %}
+                    <a href="{% url 'post-detail' previous_post.pk %}" class="btn btn-outline-secondary">
+                        Previous
+                    </a>
+                {% endif %}
+                {% if next_post %}
+                    <a href="{% url 'post-detail' next_post.pk %}" class="btn btn-outline-secondary">
+                        Next
+                    </a>
+                {% endif %}
+            </div>
+            <a href="{% url 'post-list' %}" class="btn btn-outline-secondary float-end ms-2">
                 Back to Posts
             </a>
+
         </div>
     </div>
 {% endblock %}

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -10,8 +10,6 @@ class BlogPostListViewTests(TestCase):
         response = self.client.get(reverse('post-list'))
         self.assertContains(response, 'All Blog Posts')
 
-
-
 from django.test import TestCase
 from django.urls import reverse
 
@@ -28,4 +26,18 @@ class HomePageTests(TestCase):
         response = self.client.get(reverse('home'))
         self.assertContains(response, 'ようこそ〜私のブログ！')
 
+from django.test import TestCase
+from django.urls import reverse
+from .models import Post
+
+class PostNavigationTests(TestCase):
+    def setUp(self):
+        self.post1 = Post.objects.create(title='Post 1', content='Content 1')
+        self.post2 = Post.objects.create(title='Post 2', content='Content 2')
+        self.post3 = Post.objects.create(title='Post 3', content='Content 3')
+
+    def test_post_navigation(self):
+        response = self.client.get(reverse('post-detail', args=[self.post2.pk]))
+        self.assertContains(response, reverse('post-detail', args=[self.post1.pk]))
+        self.assertContains(response, reverse('post-detail', args=[self.post3.pk]))
 

--- a/blog/views.py
+++ b/blog/views.py
@@ -23,6 +23,13 @@ class PostDetailView(DetailView):
     model = Post
     template_name = 'blog/post_detail.html'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        post = self.object
+        context['previous_post'] = Post.objects.filter(pk__lt=post.pk).order_by('-pk').first()
+        context['next_post'] = Post.objects.filter(pk__gt=post.pk).order_by('pk').first()
+        return context
+
 class PostCreateView(CreateView):
     model = Post
     template_name = 'blog/post_form.html'
@@ -39,3 +46,4 @@ class PostDeleteView(DeleteView):
     model = Post
     template_name = 'blog/post_confirm_delete.html'
     success_url = reverse_lazy('home')
+


### PR DESCRIPTION
This pull request fixes #9.

The issue has been successfully resolved. The AI agent has confirmed that all tests have passed, indicating that the "next" and "previous" buttons have been correctly added to the post detail page. These buttons now allow users to navigate to the next or previous post.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌